### PR TITLE
Make compliant to Django 1.11

### DIFF
--- a/django_sorting/middleware.py
+++ b/django_sorting/middleware.py
@@ -1,13 +1,13 @@
-def get_field(self):
+def get_field(request):
     try:
-        field = self.REQUEST['sort']
+        field = request['sort']
     except (KeyError, ValueError, TypeError):
         field = ''
-    return (self.direction == 'desc' and '-' or '') + field
+    return (request.direction == 'desc' and '-' or '') + field
 
-def get_direction(self):
+def get_direction(request):
     try:
-        return self.REQUEST['dir']
+        return request['dir']
     except (KeyError, ValueError, TypeError):
         return 'desc'
 

--- a/django_sorting/templatetags/sorting_tags.py
+++ b/django_sorting/templatetags/sorting_tags.py
@@ -133,7 +133,8 @@ class SortedDataNode(template.Node):
 
         # Python sorting if not a field
         field = ordering[1:] if ordering[0] == '-' else ordering
-        return field not in queryset.model._meta.get_all_field_names()
+        field_names = [f.name for f in queryset.model._meta.get_fields()]
+        return field not in field_names
 
     def render(self, context):
         if self.context_var is not None:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except ImportError:
     from distutils.core import setup
     package_list = ['django_sorting']
 
-version = '0.4+incuna.1'
+version = '0.4+incuna.2'
 
 setup(
     name='django-sorting',


### PR DESCRIPTION
# Make compliant to Django 1.11
_This PR makes the `django_sorting` package compliant with Django 1.11 by removing the redundant request.REQUEST structure and moving away from the old `meta` API._

* Replace `self.REQUEST` with `request`
* Remove `get_all_field_names` and replace with a list comprehension using `get_fields`