### PR TITLE
Get field from request

### DIFF
--- a/django_sorting/middleware.py
+++ b/django_sorting/middleware.py
@@ -1,13 +1,13 @@
 def get_field(request):
     try:
-        field = request['sort']
+        field = request.GET['sort']
     except (KeyError, ValueError, TypeError):
         field = ''
     return (request.direction == 'desc' and '-' or '') + field
 
 def get_direction(request):
     try:
-        return request['dir']
+        return request.GET['dir']
     except (KeyError, ValueError, TypeError):
         return 'desc'
 

--- a/django_sorting/templatetags/sorting_tags.py
+++ b/django_sorting/templatetags/sorting_tags.py
@@ -87,7 +87,7 @@ class SortAnchorNode(template.Node):
         else:
             icon = ''
 
-        if len(list(getvars.keys())) > 0:
+        if len(getvars.keys()) > 0:
             urlappend = "&%s" % getvars.urlencode()
         else:
             urlappend = ''

--- a/django_sorting/templatetags/sorting_tags.py
+++ b/django_sorting/templatetags/sorting_tags.py
@@ -87,7 +87,7 @@ class SortAnchorNode(template.Node):
         else:
             icon = ''
 
-        if len(getvars.keys()) > 0:
+        if len(list(getvars.keys())) > 0:
             urlappend = "&%s" % getvars.urlencode()
         else:
             urlappend = ''
@@ -103,8 +103,8 @@ class SortAnchorNode(template.Node):
 
 def autosort(parser, token):
     bits = [b.strip('"\'') for b in token.split_contents()]
-    help_msg = u'autosort tag synopsis: {%% autosort queryset [as '\
-        u'context_variable] %%}'
+    help_msg = 'autosort tag synopsis: {%% autosort queryset [as '\
+        'context_variable] %%}'
     context_var = None
 
     # Check if has not required "as new_context_var" part
@@ -179,7 +179,7 @@ class SortedDataNode(template.Node):
         else:
             context[key] = queryset
 
-        return u''
+        return ''
 
 
 anchor = register.tag(anchor)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except ImportError:
     from distutils.core import setup
     package_list = ['django_sorting']
 
-version = '0.4.2'
+version = '0.4.3'
 
 setup(
     name='django-sorting',


### PR DESCRIPTION
# Get field from request
_This PR fixes the retrieval of the `field` and `direction` parameters from the GET dict in the request._

* Fix naive `request[]` with replacement for proper `request.GET[]` 
* Bump up version to v0.4.3